### PR TITLE
Remove Clang warning in Category

### DIFF
--- a/Categories/NSObject+InvocationUtils.m
+++ b/Categories/NSObject+InvocationUtils.m
@@ -17,7 +17,7 @@
         [objects addObject:obj1];
         va_start(args, obj1);         
         
-        while (argitem = va_arg(args, id)) {
+        while ((argitem = va_arg(args, id))) {
             [objects addObject:argitem];               
         }
         


### PR DESCRIPTION
This change removes a warning when using Clang as the compile for the category NSObject+InvocationUtils.m that's added directly to the project. 

The change that clang expects is that assignments being used as a part of conditional statements need to be wrapped in parentheses to be explicit that this is the intended action instead of an equality check. 
