### PR TITLE
Add @class UVSubject declaration to fix compile error

### DIFF
--- a/Classes/UVTicket.h
+++ b/Classes/UVTicket.h
@@ -9,6 +9,7 @@
 #import <Foundation/Foundation.h>
 #import "UVBaseModel.h"
 
+@class UVSubject;
 
 @interface UVTicket : UVBaseModel {    
 }


### PR DESCRIPTION
The UVTicket.h file has a reference to UVSubject without a @class declaration or an #import of UVSubject. This commit adds the @class declaration to allow the project to compile.
