### PR TITLE
Changed iTunes Store URL to go straight to ratings (as per Appirater)

### DIFF
--- a/Classes/UVWelcomeViewController.m
+++ b/Classes/UVWelcomeViewController.m
@@ -69,7 +69,7 @@
 
 - (void)alertView:(UIAlertView *)alertView clickedButtonAtIndex:(NSInteger)buttonIndex {
 	if (buttonIndex == alertView.firstOtherButtonIndex) {
-		NSString *url = [NSString stringWithFormat:@"http://phobos.apple.com/WebObjects/MZStore.woa/wa/viewSoftware?id=%@",
+		NSString *url = [NSString stringWithFormat:@"itms-apps://ax.itunes.apple.com/WebObjects/MZStore.woa/wa/viewContentsUserReviews?type=Purple+Software&id=%@",
 						 [UVSession currentSession].clientConfig.itunesApplicationId];
 		
 		NSLog(@"Attempting to open iTunes page: %@", url);


### PR DESCRIPTION
Rather than just going to the app page in the store, jump straight to the ratings page.

Substituted the URL for the one in [Appirater](/arashpayan/appirater) (see [Appirater.m templateReviewURL](/arashpayan/appirater/blob/master/Appirater.m#L49))
