### PR TITLE
Fix <null> value crash for UVClientConfig questions_enabled

### DIFF
--- a/Classes/UVClientConfig.m
+++ b/Classes/UVClientConfig.m
@@ -42,8 +42,10 @@
 }
 
 - (id)initWithDictionary:(NSDictionary *)dict {
-	if (self = [super init]) {
-		self.questionsEnabled = [(NSNumber *)[dict objectForKey:@"questions_enabled"] boolValue];
+	if ((self = [super init])) {
+        if ([dict objectForKey:@"questions_enabled"] != [NSNull null]) {
+            self.questionsEnabled = [(NSNumber *)[dict objectForKey:@"questions_enabled"] boolValue];
+        }
 		self.welcome = [self objectOrNilForDict:dict key:@"welcome"];
 		self.itunesApplicationId = [self objectOrNilForDict:dict key:@"identifier_external"];
 		


### PR DESCRIPTION
Hi,

I add an error when launching the modal view caused bu a null value from a response of a request, so I add an extra validation to avoid the <i>sigAlert crash</i>:

> -[NSNull boolValue]: unrecognized selector sent to instance 0x25fb5e8
> **\* Terminating app due to uncaught exception 'NSInvalidArgumentException', reason: '-[NSNull boolValue]: >unrecognized selector sent to instance 0x25fb5e8'```

In the dictionary of <i>UVClientConfig</i> class method <i>initWithDictionary</i> (line :46)
I had "questions_enabled" = "<null>";
Don't know if it's a problem from server response or not.

Besides, I don't really understand the difference on the administration panel between <i>iOS Apps</i> and <i>API</i> which refers both to the same SDK.

Thanks in advance for any feedback on that.
