### PR TITLE
"xcodebuild" build error with iphonesimulator5.0 SDK (Xcode 4.2.1)

### DIFF
--- a/UserVoice.xcodeproj/project.pbxproj
+++ b/UserVoice.xcodeproj/project.pbxproj
@@ -1118,10 +1118,7 @@
 			buildSettings = {
 				ADDITIONAL_SDKS = "";
 				ALWAYS_SEARCH_USER_PATHS = NO;
-				ARCHS = (
-					armv7,
-					armv6,
-				);
+				ARCHS = "$(ARCHS_STANDARD_32_BIT)";
 				CONFIGURATION_BUILD_DIR = "$(BUILT_PRODUCTS_DIR)";
 				CONFIGURATION_TEMP_DIR = "$(BUILT_PRODUCTS_DIR)";
 				COPY_PHASE_STRIP = NO;
@@ -1152,6 +1149,7 @@
 				SDKROOT = iphoneos;
 				SKIP_INSTALL = YES;
 				USER_HEADER_SEARCH_PATHS = "Vendor/JSON/** Vendor/HTTPRiot/** Vendor/YOAuth/**";
+				VALID_ARCHS = "i386 armv6 armv7";
 				VERSIONING_SYSTEM = "apple-generic";
 				VERSION_INFO_PREFIX = USERVOICE;
 			};
@@ -1162,10 +1160,7 @@
 			buildSettings = {
 				ADDITIONAL_SDKS = "";
 				ALWAYS_SEARCH_USER_PATHS = NO;
-				ARCHS = (
-					armv7,
-					armv6,
-				);
+				ARCHS = "$(ARCHS_STANDARD_32_BIT)";
 				CONFIGURATION_BUILD_DIR = "$(BUILT_PRODUCTS_DIR)";
 				CONFIGURATION_TEMP_DIR = "$(BUILT_PRODUCTS_DIR)";
 				CURRENT_PROJECT_VERSION = 0.1;
@@ -1193,6 +1188,7 @@
 				SDKROOT = iphoneos;
 				SKIP_INSTALL = YES;
 				USER_HEADER_SEARCH_PATHS = "Vendor/JSON/** Vendor/HTTPRiot/** Vendor/YOAuth/**";
+				VALID_ARCHS = "i386 armv6 armv7";
 				VERSIONING_SYSTEM = "apple-generic";
 				VERSION_INFO_PREFIX = USERVOICE;
 			};


### PR DESCRIPTION
xcodebuild -target UserVoice -configuration Release -sdk iphonesimulator
Build settings from command line:
    SDKROOT = iphonesimulator5.0

=== BUILD NATIVE TARGET UserVoice OF PROJECT UserVoice WITH CONFIGURATION Release ===
Check dependencies
[BEROR]No architectures to compile for (ARCHS=armv7 armv6, VALID_ARCHS=i386).

*\* BUILD FAILED **

The following build commands failed:
    Check dependencies
(1 failure)
