### PR TITLE
Fixed creation of UIColors with format rrggbb 

### DIFF
--- a/Categories/UVUIColorAdditions.m
+++ b/Categories/UVUIColorAdditions.m
@@ -25,7 +25,7 @@
 // Returns a UIColor by scanning the string for a hex number and passing that to +[UIColor colorWithRGBHex:]
 // Skips any leading whitespace and ignores any trailing characters
 + (UIColor *)colorWithHexString:(NSString *)stringToConvert {
-    if ([stringToConvert length] > 0 && [stringToConvert characterAtIndex:0]) {
+    if ([stringToConvert length] > 0 && [stringToConvert characterAtIndex:0] == '#') {
         // Account for #rrggbb format (instead of 0xrrggbb or rrggbb)
         stringToConvert = [stringToConvert substringFromIndex:1];
     }


### PR DESCRIPTION
The first character was always stripped from the format:
If someone passed a color without a leading # (for example FF0000),
the first character was removed, so most of the red part of the color
was lost (for the example the color would be F0000 = 0F0000)
