### PR TITLE
Added custom text at the end of the support request

### DIFF
--- a/Classes/UVBaseTicketViewController.m
+++ b/Classes/UVBaseTicketViewController.m
@@ -59,10 +59,12 @@
     self.userName = nameField.text;
     self.text = textView.text;
     
-    //Add technical info and content of the log
-    self.text = [self.text stringByAppendingString:[selectedCustomFieldValues objectForKey:@"Technical Information"]];
-    //End of local modification
-
+    //Append custom text at the end of the message
+    UVConfig *config = [UVSession currentSession].config;
+    if(config.customMessage != nil){
+        self.text = [self.text stringByAppendingString:config.customMessage];
+    }
+    
     if ([UVSession currentSession].user || (emailField.text.length > 1)) {
         [self showActivityIndicator];
         [UVTicket createWithMessage:self.text andEmailIfNotLoggedIn:emailField.text andName:nameField.text andCustomFields:selectedCustomFieldValues andDelegate:self];

--- a/Classes/UVConfig.m
+++ b/Classes/UVConfig.m
@@ -25,6 +25,7 @@
 @synthesize showPostIdea;
 @synthesize showContactUs;
 @synthesize showKnowledgeBase;
+@synthesize customMessage;
 
 + (UVConfig *)configWithSite:(NSString *)site andKey:(NSString *)key andSecret:(NSString *)secret {
     return [[[UVConfig alloc] initWithSite:site andKey:key andSecret:secret] autorelease];

--- a/Include/UVConfig.h
+++ b/Include/UVConfig.h
@@ -41,6 +41,9 @@
 @property (nonatomic, assign) BOOL showContactUs;
 @property (nonatomic, assign) BOOL showKnowledgeBase;
 
+// A custom message that will be added to the end of each new ticket
+@property (nonatomic, retain) NSString* customMessage;
+
 - (id)initWithSite:(NSString *)theSite andKey:(NSString *)theKey andSecret:(NSString *)theSecret;
 - (id)initWithSite:(NSString *)theSite andKey:(NSString *)theKey andSecret:(NSString *)theSecret andSSOToken:(NSString *)theToken;
 - (id)initWithSite:(NSString *)theSite andKey:(NSString *)theKey andSecret:(NSString *)theSecret andEmail:(NSString *)theEmail andDisplayName:(NSString *)theDisplayName andGUID:(NSString *)theGuid;


### PR DESCRIPTION
This pull request adds a new config option to add custom text at the end of new support request. This is useful for sending log or other text data that would not be suitable for custom fields.
