### PR TITLE
remove usage of undefined NSFoundationVersionNumber_iOS_6_1

### DIFF
--- a/Classes/UVArticleViewController.m
+++ b/Classes/UVArticleViewController.m
@@ -48,7 +48,7 @@
 
     UIToolbar *helpfulBar = [[[UIToolbar alloc] initWithFrame:CGRectMake(0, self.view.bounds.size.height - 40, self.view.bounds.size.width, 40)] autorelease];
     helpfulBar.autoresizingMask = UIViewAutoresizingFlexibleWidth|UIViewAutoresizingFlexibleTopMargin;
-    if (floor(NSFoundationVersionNumber) <= NSFoundationVersionNumber_iOS_6_1) {
+    if (floor(NSFoundationVersionNumber) <= 993.00) {
         helpfulBar.barStyle = UIBarStyleBlack;
         helpfulBar.tintColor = [UIColor colorWithRed:1.00f green:0.99f blue:0.90f alpha:1.0f];
     }


### PR DESCRIPTION
NSFoundationVersionNumber_iOS_6_1 was only defined in the iOS 7 sdk, so it shouldn't be used yet. the code won't compile in xcode 4.6, 
