### PR TITLE
avoid header naming collisions with Base64Transcoder.h

### DIFF
--- a/Vendor/YOAuth/YOAuthSignatureMethod_HMAC-SHA1.m
+++ b/Vendor/YOAuth/YOAuthSignatureMethod_HMAC-SHA1.m
@@ -12,7 +12,7 @@
 
 #import <CommonCrypto/CommonHMAC.h>
 
-#include "Base64Transcoder.h"
+#include "Crypto/Base64Transcoder.h"
 
 @implementation YOAuthSignatureMethod_HMAC_SHA1
 


### PR DESCRIPTION
This change avoids header name collisions when a project contains another file
named Base64Transcoder.h (e.g., OAuthConsumer).

Fixes #173.
