### PR TITLE
Fix for IOS7 non-nilled delegate crasher

### DIFF
--- a/Classes/UVSuggestionListViewController.m
+++ b/Classes/UVSuggestionListViewController.m
@@ -333,6 +333,8 @@
 }
 
 - (void)dealloc {
+    self.tableView.delegate = nil;
+    self.tableView.dataSource = nil;
     self.forum = nil;
     self.suggestions = nil;
     self.searchResults = nil;


### PR DESCRIPTION
Fix for an IOS7 crash that occurs upon exiting the suggestion list view controller after scrolling.
