### PR TITLE
Added navigationBarTintColor style option and set all navigationbar item...

### DIFF
--- a/Classes/UVSuggestionListViewController.m
+++ b/Classes/UVSuggestionListViewController.m
@@ -284,8 +284,6 @@
         self.navigationItem.rightBarButtonItem = [[UIBarButtonItem alloc] initWithBarButtonSystemItem:UIBarButtonSystemItemCompose
                                                                                                target:self
                                                                                                action:@selector(composeButtonTapped)];
-        if ([self.navigationItem.rightBarButtonItem respondsToSelector:@selector(setTintColor:)])
-            self.navigationItem.rightBarButtonItem.tintColor = [UIColor colorWithRed:0.24f green:0.51f blue:0.95f alpha:1.0f];
     }
 
     if ([UVSession currentSession].isModal && _firstController) {

--- a/Classes/UVUtils.m
+++ b/Classes/UVUtils.m
@@ -228,7 +228,7 @@ static const char encodingTable[] = "ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopq
 + (void)applyStylesheetToNavigationController:(UINavigationController *)navigationController {
     UVStyleSheet *styles = [UVStyleSheet instance];
     if (IOS7) {
-        navigationController.navigationBar.tintColor = styles.tintColor;
+        navigationController.navigationBar.tintColor = styles.navigationBarTintColor;
         navigationController.navigationBar.backgroundColor = styles.navigationBarBackgroundColor;
     } else {
         navigationController.navigationBar.tintColor = styles.navigationBarBackgroundColor;

--- a/Include/UVStyleSheet.h
+++ b/Include/UVStyleSheet.h
@@ -20,6 +20,7 @@
 @property (nonatomic, retain) UIColor *navigationBarTextShadowColor;
 @property (nonatomic, retain) UIImage *navigationBarBackgroundImage;
 @property (nonatomic, retain) UIFont  *navigationBarFont;
+@property (nonatomic, retain) UIColor *navigationBarTintColor;
 @property (nonatomic, retain) UIColor *loadingViewBackgroundColor;
 
 @end


### PR DESCRIPTION
Added a new styled called "NavigationBarTintColor" which governs the tint color for all navigation items. Unfortunately, the previous way to change colors for navigation items was via the "tintColor" property which was tied to the tint for the view. This led to situations where you'd have white navigation bar items and a white text carrot (which would be invisible). This decouples the styling of the view's tint color with the navigationbar's tint color.

In addition, I removed the hardcoded value for the "add suggestion" navigation button which was tied to the color "blue" regardless of the actual tint color set.
