### PR TITLE
Fix ordering of dismissal delegate call

### DIFF
--- a/Classes/UVBaseViewController.m
+++ b/Classes/UVBaseViewController.m
@@ -39,10 +39,12 @@
     if (_firstController && [[UserVoice delegate] respondsToSelector:@selector(userVoiceRequestsDismissal)]) {
         [[UserVoice delegate] userVoiceRequestsDismissal];
     } else {
-        [self dismissViewControllerAnimated:YES completion:nil];
-        if (_firstController && [[UserVoice delegate] respondsToSelector:@selector(userVoiceWasDismissed)]) {
-            [[UserVoice delegate] userVoiceWasDismissed];
-        }
+        [self dismissViewControllerAnimated:YES
+                                 completion:^{
+                                     if (_firstController && [[UserVoice delegate] respondsToSelector:@selector(userVoiceWasDismissed)]) {
+                                         [[UserVoice delegate] userVoiceWasDismissed];
+                                     }
+                                 }];
     }
 }
 


### PR DESCRIPTION
Now sends `userVoiceWasDismissed` to the delegate only after UserVoice was actually dismissed.
