### PR TITLE
Fix library failing to link when compiling app for armv7s.

### DIFF
--- a/UserVoice.xcodeproj/project.pbxproj
+++ b/UserVoice.xcodeproj/project.pbxproj
@@ -904,6 +904,11 @@
 			buildSettings = {
 				ADDITIONAL_SDKS = "";
 				ALWAYS_SEARCH_USER_PATHS = NO;
+				ARCHS = (
+					armv7,
+					armv7s,
+					arm64,
+				);
 				CLANG_ENABLE_OBJC_ARC = YES;
 				CLANG_WARN_BOOL_CONVERSION = YES;
 				CLANG_WARN_CONSTANT_CONVERSION = YES;
@@ -968,6 +973,11 @@
 			buildSettings = {
 				ADDITIONAL_SDKS = "";
 				ALWAYS_SEARCH_USER_PATHS = NO;
+				ARCHS = (
+					armv7,
+					armv7s,
+					arm64,
+				);
 				CLANG_ENABLE_OBJC_ARC = YES;
 				CLANG_WARN_BOOL_CONVERSION = YES;
 				CLANG_WARN_CONSTANT_CONVERSION = YES;
@@ -1117,6 +1127,11 @@
 			buildSettings = {
 				ADDITIONAL_SDKS = "";
 				ALWAYS_SEARCH_USER_PATHS = NO;
+				ARCHS = (
+					armv7,
+					armv7s,
+					arm64,
+				);
 				CLANG_ENABLE_OBJC_ARC = YES;
 				CLANG_WARN_BOOL_CONVERSION = YES;
 				CLANG_WARN_CONSTANT_CONVERSION = YES;


### PR DESCRIPTION
Xcode 6 changes the standard architectures to exclude armv7s — the instruction set used by the iPhone 5, 5C and iPad 4, which is a variant of the armv7 instruction set. [Read more on Apple’s developer forums](https://devforums.apple.com/thread/244407).

UserVoice uses the standard architectures, so fails to link if a user of the library is compiling for armv7s.

As a library, UserVoice ought to include as many architectures as possible to accommodate the applications linking with it. This pull request changes the UserVoice project to explicitly specify architectures to add armv7s.
