### PR TITLE
Call super implementation when overriding methods

### DIFF
--- a/Classes/UVBaseViewController.m
+++ b/Classes/UVBaseViewController.m
@@ -55,7 +55,7 @@
     barFrame = self.navigationController.navigationBar.frame;
     CGRect appFrame = [UIScreen mainScreen].applicationFrame;
     CGFloat yStart = barFrame.origin.y + barFrame.size.height;
-    
+
     return CGRectMake(0, yStart, appFrame.size.width, appFrame.size.height - barFrame.size.height);
 }
 
@@ -90,7 +90,7 @@
     if (!self.navigationItem) {
         return;
     }
-    
+
     if (self.navigationItem.rightBarButtonItem) {
         self.navigationItem.rightBarButtonItem.enabled = enabled;
     }
@@ -205,7 +205,7 @@
             parent.view.superview.frame = parent.presentedViewController.view.superview.frame;
         }
     }
-    
+
     [super willAnimateRotationToInterfaceOrientation:toInterfaceOrientation duration:duration];
 }
 
@@ -232,7 +232,7 @@
             parent.view.superview.hidden = NO;
         }
     }
-    
+
     if (!IOS7 && _tableView) {
         [_tableView reloadData];
     }
@@ -299,7 +299,7 @@
     [[NSNotificationCenter defaultCenter] addObserver:self
                                              selector:@selector(keyboardWillHide:)
                                                  name:UIKeyboardWillHideNotification object:nil];
-    
+
     [[NSNotificationCenter defaultCenter] addObserver:self
                                              selector:@selector(keyboardDidHide:)
                                                  name:UIKeyboardDidHideNotification object:nil];
@@ -527,6 +527,7 @@
 
 - (void) viewWillDisappear:(BOOL)animated {
     [self.tableView setContentOffset:self.tableView.contentOffset animated:NO];
+    [super viewWillDisappear:animated];
 }
 
 - (void)dealloc {


### PR DESCRIPTION
The implementation of `-viewWillDisappear:` in `UVBaseViewController` forgets to call the implementation of super class.
