### PR TITLE
nil out answer manager's delegate after controller dismissed

### DIFF
--- a/Classes/UVWelcomeViewController.m
+++ b/Classes/UVWelcomeViewController.m
@@ -347,6 +347,11 @@
     [_tableView reloadData];
 }
 
+- (void)dismiss {    
+    _instantAnswerManager.delegate = nil;
+    [super dismiss];
+}
+
 - (void)viewWillAppear:(BOOL)animated {
     [_tableView reloadData];
     [super viewWillAppear:animated];


### PR DESCRIPTION
to prevent bad memory access crash
https://github.com/uservoice/uservoice-ios-sdk/issues/325
