### PR TITLE
Fixed navigation bar coloring issue on iOS 7 and 8

### DIFF
--- a/Classes/UVUtils.m
+++ b/Classes/UVUtils.m
@@ -229,9 +229,9 @@ static const char encodingTable[] = "ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopq
 
 + (void)applyStylesheetToNavigationController:(UINavigationController *)navigationController {
     UVStyleSheet *styles = [UVStyleSheet instance];
-    if (IOS7) {
+    if (IOS7 || IOS8) {
         navigationController.navigationBar.tintColor = styles.navigationBarTintColor;
-        navigationController.navigationBar.backgroundColor = styles.navigationBarBackgroundColor;
+        navigationController.navigationBar.barTintColor = styles.navigationBarBackgroundColor;
     } else {
         navigationController.navigationBar.tintColor = styles.navigationBarBackgroundColor;
     }


### PR DESCRIPTION
According to apple, "In iOS v7.0, all subclasses of UIView derive their behavior for tintColor from the base class. See the discussion of tintColor at the UIView level for more information." Therefore the background color is actually `barTintColor` and `tintColor` is literally the text color.

This would make color configuration easier.