### PR TITLE
Fixed invalid #import in YOAuth

### DIFF
--- a/Vendor/YOAuth/YOAuth.h
+++ b/Vendor/YOAuth/YOAuth.h
@@ -13,7 +13,7 @@
  */
 
 #import "YOAuthConsumer.h"
-#import "YOAUthToken.h"
+#import "YOAuthToken.h"
 #import "YOAuthRequest.h"
 #import "YOAuthUtil.h"
 #import "YOAuthSignatureMethod.h"


### PR DESCRIPTION
Fixed invalid #import causing build error on case-sensitive file systems