### PR TITLE
On iOS 8 / iPad, display "Contact Us" modal view, after the UIAltertView in an article

### DIFF
--- a/Classes/UVArticleViewController.m
+++ b/Classes/UVArticleViewController.m
@@ -91,7 +91,9 @@
         }
     } else {
         if (buttonIndex == 0) {
-            [self presentModalViewController:[UVContactViewController new]];
+            dispatch_async(dispatch_get_main_queue(), ^ {
+                [self presentModalViewController:[UVContactViewController new]];
+            });
         }
     }
 }


### PR DESCRIPTION
....

Avoid "Warning: Attempt to present <UINavigationController: XXX>  on <UVArticleViewController: XXX> which is already presenting (null)".