### PR TITLE
Fix userVoiceWasDismissed not being called

### DIFF
--- a/Classes/UVContactViewController.m
+++ b/Classes/UVContactViewController.m
@@ -171,6 +171,7 @@
     [self clearDraft];
     [UVBabayaga track:SUBMIT_TICKET];
     UVSuccessViewController *next = [UVSuccessViewController new];
+    next.firstController = self.firstController;
     next.titleText = NSLocalizedStringFromTableInBundle(@"Message sent!", @"UserVoice", [UserVoice bundle], nil);
     next.text = NSLocalizedStringFromTableInBundle(@"We'll be in touch.", @"UserVoice", [UserVoice bundle], nil);
     [self.navigationController setViewControllers:@[next] animated:YES];

--- a/Classes/UVPostIdeaViewController.m
+++ b/Classes/UVPostIdeaViewController.m
@@ -261,6 +261,7 @@
 - (void)didCreateSuggestion:(UVSuggestion *)theSuggestion {
     [UVBabayaga track:SUBMIT_IDEA];
     UVSuccessViewController *next = [UVSuccessViewController new];
+    next.firstController = self.firstController;
     next.titleText = NSLocalizedStringFromTableInBundle(@"Thank you!", @"UserVoice", [UserVoice bundle], nil);
     next.text = NSLocalizedStringFromTableInBundle(@"Your feedback has been posted to our feedback forum.", @"UserVoice", [UserVoice bundle], nil);
     [self.navigationController setViewControllers:@[next] animated:YES];


### PR DESCRIPTION
userVoiceWasDismissed does not get called when using presentUserVoiceContactUsFormForParentViewController or presentUserVoiceNewIdeaFormForParentViewController and the user actually creates a ticket or suggestion. In that case the UVSuccessViewController replaces the UVContactViewController or UVPostIdeaViewController instances and thus becomes the "firstController".

This fixes issue #304 