### PR TITLE
Fixed a rotation issue when presenting UserVoiceInterfaceForParentViewController in an iPad

### DIFF
--- a/Classes/UVArticle.m
+++ b/Classes/UVArticle.m
@@ -19,7 +19,7 @@
 
 + (id)getArticlesWithTopicId:(NSInteger)topicId page:(NSInteger)page delegate:(id<UVModelDelegate>)delegate {
     NSString *path = [self apiPath:[NSString stringWithFormat:@"/topics/%d/articles.json", (int)topicId]];
-    NSDictionary *params = @{ @"sort" : @"ordered", @"page" : [NSString stringWithFormat:@"%d", (int)page] };
+    NSDictionary *params = @{ @"sort" : @"ordered", @"page" : [NSString stringWithFormat:@"%d", (int)page], @"filter" : @"published" };
     return [self getPath:path
               withParams:params
                   target:delegate
@@ -29,7 +29,7 @@
 
 + (id)getArticlesWithPage:(NSInteger)page delegate:(id<UVModelDelegate>)delegate {
     NSString *path = [self apiPath:@"/articles.json"];
-    NSDictionary *params = @{ @"sort" : @"ordered", @"page" : [NSString stringWithFormat:@"%d", (int)page] };
+    NSDictionary *params = @{ @"sort" : @"ordered", @"page" : [NSString stringWithFormat:@"%d", (int)page], @"filter" : @"published" };
     return [self getPath:path
               withParams:params
                   target:delegate

--- a/Classes/UVBaseViewController.m
+++ b/Classes/UVBaseViewController.m
@@ -200,7 +200,7 @@
     // We are the top modal, make to sure that parent modals use our size
     if (self.needNestedModalHack && self.presentedViewController == nil && self.presentingViewController) {
         for (UIViewController* parent = self.presentingViewController;
-             parent.presentingViewController;
+             [parent isKindOfClass:UVBaseViewController.class]&&parent.presentingViewController;
              parent = parent.presentingViewController) {
             parent.view.superview.frame = parent.presentedViewController.view.superview.frame;
         }
@@ -214,7 +214,7 @@
     // We are the top modal, make to sure that parent modals are hidden during transition
     if (self.needNestedModalHack && self.presentedViewController == nil && self.presentingViewController) {
         for (UIViewController* parent = self.presentingViewController;
-             parent.presentingViewController;
+             [parent isKindOfClass:UVBaseViewController.class]&&parent.presentingViewController;
              parent = parent.presentingViewController) {
             parent.view.superview.hidden = YES;
         }
@@ -227,7 +227,7 @@
     // We are the top modal, make to sure that parent modals are shown after animation
     if (self.needNestedModalHack && self.presentedViewController == nil && self.presentingViewController) {
         for (UIViewController* parent = self.presentingViewController;
-             parent.presentingViewController;
+            [parent isKindOfClass:UVBaseViewController.class]&&parent.presentingViewController;
              parent = parent.presentingViewController) {
             parent.view.superview.hidden = NO;
         }

--- a/Classes/UVBaseViewController.m
+++ b/Classes/UVBaseViewController.m
@@ -200,7 +200,7 @@
     // We are the top modal, make to sure that parent modals use our size
     if (self.needNestedModalHack && self.presentedViewController == nil && self.presentingViewController) {
         for (UIViewController* parent = self.presentingViewController;
-             [parent isKindOfClass:UVBaseViewController.class]&&parent.presentingViewController;
+             [parent isKindOfClass:UVBaseViewController.class] && parent.presentingViewController;
              parent = parent.presentingViewController) {
             parent.view.superview.frame = parent.presentedViewController.view.superview.frame;
         }
@@ -214,7 +214,7 @@
     // We are the top modal, make to sure that parent modals are hidden during transition
     if (self.needNestedModalHack && self.presentedViewController == nil && self.presentingViewController) {
         for (UIViewController* parent = self.presentingViewController;
-             [parent isKindOfClass:UVBaseViewController.class]&&parent.presentingViewController;
+             [parent isKindOfClass:UVBaseViewController.class] && parent.presentingViewController;
              parent = parent.presentingViewController) {
             parent.view.superview.hidden = YES;
         }
@@ -227,7 +227,7 @@
     // We are the top modal, make to sure that parent modals are shown after animation
     if (self.needNestedModalHack && self.presentedViewController == nil && self.presentingViewController) {
         for (UIViewController* parent = self.presentingViewController;
-            [parent isKindOfClass:UVBaseViewController.class]&&parent.presentingViewController;
+            [parent isKindOfClass:UVBaseViewController.class] && parent.presentingViewController;
              parent = parent.presentingViewController) {
             parent.view.superview.hidden = NO;
         }

--- a/Classes/UVHelpTopic.m
+++ b/Classes/UVHelpTopic.m
@@ -14,7 +14,7 @@
 + (id)getAllWithDelegate:(id<UVModelDelegate>)delegate {
     NSString *path = [self apiPath:@"/topics.json"];
     return [self getPath:path
-              withParams:nil
+              withParams:@{@"per_page":@"99"}
                   target:delegate
                 selector:@selector(didRetrieveHelpTopics:)
                  rootKey:@"topics"];


### PR DESCRIPTION
When the iPad is rotated, the UVBaseViewController.m has code to resize all the presenting view controllers, including those not in UserVoice, the fix prevents any presenting non-UVBaseViewController from being resized.

This pull requests contains a previous accepted pull request #357, but I guess it is showing here again because its the same branch and hasn't been merged into master.

Thanks!
Salvador