### PR TITLE
Add missing return type for `getInstantAnswers`

### DIFF
--- a/Classes/UVArticle.h
+++ b/Classes/UVArticle.h
@@ -12,7 +12,7 @@
 
 @interface UVArticle : UVBaseModel
 
-+ getInstantAnswers:(NSString *)query delegate:(id<UVModelDelegate>)delegate;
++ (NSArray *)getInstantAnswers:(NSString *)query delegate:(id<UVModelDelegate>)delegate;
 + (id)getArticlesWithTopicId:(NSInteger)topicId page:(NSInteger)page delegate:(id<UVModelDelegate>)delegate;
 + (id)getArticlesWithPage:(NSInteger)page delegate:(id<UVModelDelegate>)delegate;
 


### PR DESCRIPTION
I'm a little surprised how it works now... :) I actually thought it's required to specify return type.