### PR TITLE
Fix bundle path

### DIFF
--- a/Classes/UserVoice.m
+++ b/Classes/UserVoice.m
@@ -31,7 +31,7 @@ static NSBundle *userVoiceBundle;
 
 + (NSBundle *)bundle {
     if (!userVoiceBundle) {
-        NSURL *url = [[NSBundle mainBundle] URLForResource:@"UserVoice" withExtension:@"bundle"];
+        NSURL *url = [[NSBundle bundleForClass:self] URLForResource:@"UserVoice" withExtension:@"bundle"];
         if (url) {
             userVoiceBundle = [NSBundle bundleWithURL:url];
         }


### PR DESCRIPTION
Steps to repro.

1. Add uservoice sdk as a framework (i.e. using CocoaPods)
```
platform :ios, :deployment_target => '8.1'
use_frameworks!
pod 'uservoice-iphone-sdk'
```
Result: `UserVoice#bundle` will be equal NSBundle#mainBundle.
As a result images from uservoice's bundle won't be accessible. I.e. `po [UVUtils imageNamed:@"uv_heart.png"]` in debugger will return `nil`.