### PR TITLE
BUGFIX: get articles after token (SO-341) 

### DIFF
--- a/Classes/UVInitialLoadManager.m
+++ b/Classes/UVInitialLoadManager.m
@@ -96,17 +96,15 @@
     UVClientConfig *clientConfig = [UVSession currentSession].clientConfig;
     _configDone = YES;
     [self loadUser];
+    
     if (clientConfig.ticketsEnabled) {
         if ([UVSession currentSession].config.topicId) {
             [UVHelpTopic getTopicWithId:[UVSession currentSession].config.topicId delegate:self];
-            [UVArticle getArticlesWithTopicId:[UVSession currentSession].config.topicId page:1 delegate:self];
         } else {
             [UVHelpTopic getTopicsWithPage:1 delegate:self];
-            [UVArticle getArticlesWithPage:1 delegate:self];
         }
     } else {
         _topicsDone = YES;
-        _articlesDone = YES;
     }
     [self checkComplete];
 }
@@ -116,6 +114,19 @@
     [UVSession currentSession].forum = forum;
     _forumDone = YES;
     [self checkComplete];
+}
+
+- (void)getArticlesWithToken{
+     UVClientConfig *clientConfig = [UVSession currentSession].clientConfig;
+    if (clientConfig.ticketsEnabled) {
+        if ([UVSession currentSession].config.topicId) {
+           [UVArticle getArticlesWithTopicId:[UVSession currentSession].config.topicId page:1 delegate:self];
+        } else {
+           [UVArticle getArticlesWithPage:1 delegate:self];
+        }
+    } else {
+        _articlesDone = YES;
+    }
 }
 
 - (void)didCreateUser:(UVUser *)theUser {
@@ -135,6 +146,8 @@
 
 - (void)didLoadUser {
     _userDone = YES;
+    [self getArticlesWithToken];
+
     if ([UVSession currentSession].clientConfig.feedbackEnabled) {
         [UVForum getWithId:(int)[UVSession currentSession].config.forumId delegate:self];
     } else {

--- a/README.md
+++ b/README.md
@@ -187,7 +187,8 @@ The library will detect and display in the language the device is set to provide
 
 Note: UserVoice for iOS does **not** support private **forums**. This section is relevant to those using sitewide privacy.
 
-The SDK relies on being able to obtain a client key to communicate with the UserVoice API. If you have a public UserVoice site (the default) then it can obtain this key automatically, so you only need to pass your site URL. However, if you turn on site privacy, this key is also private, so you will need to pass it in. You can obtain a client key pair from the mobile settings section of the UserVoice admin console.
+The SDK relies on being able to obtain a client key to communicate with the UserVoice API. If you have a public UserVoice site (the default) then it can obtain this key automatically, so you only need to pass your site URL. However, if you turn on site privacy, this key is also private, so you will need to pass it in. You can obtain a client key pair from the mobile settings section of the UserVoice admin console. Private sites are not supported unless the user is authenticated.
+
 
 ```
 UVConfig *config = [UVConfig configWithSite:@"yoursite.uservoice.com" andKey:@"CLIENT_KEY" andSecret:@"CLIENT_SECRET"];


### PR DESCRIPTION
The new restrictions on the api make articles fail with a 401, if the uservoice site is configured with full site protection, and SSO. Therefore, get the request token first, then do the articles query. It used to be initial, now it's just after forums.