### PR TITLE
Change Spanish translation for "give feedback"

### DIFF
--- a/Resources/es.lproj/UserVoice.strings
+++ b/Resources/es.lproj/UserVoice.strings
@@ -72,7 +72,7 @@
 
 "Forgot password" = "Olvidé la contraseña";
 
-"Give feedback or ask for help..." = "Retroalimenta o pide ayuda...";
+"Give feedback or ask for help..." = "Deja tu comentario o pide ayuda...";
 
 "Great! Glad we could help." = "Excelente! Nos agrada poder ayudar.";
 


### PR DESCRIPTION
"Retroalimenta" is an inappropriate translation for this term here, and "Deja tu comentario" is in line with the rest of translations for "feedback" in the rest of the file (see line 67)