### PR TITLE
Enable bitcode compilation

### DIFF
--- a/build.sh
+++ b/build.sh
@@ -4,11 +4,11 @@ DIST=dist/UserVoiceSDK-3.2.9
 
 echo "==== Building for iOS devices ===="
 echo ""
-xcodebuild
+xcodebuild OTHER_CFLAGS="-fembed-bitcode"
 
 echo "==== Building for iOS simulator ===="
 echo ""
-xcodebuild -sdk iphonesimulator
+xcodebuild OTHER_CFLAGS="-fembed-bitcode" -sdk iphonesimulator
 
 mkdir -p $DIST
 


### PR DESCRIPTION
Updated the build script to utilize bitcode compilation.  This results in a very large assembly file, but allows the final app size to be much smaller as Apple only distributes the slice that is appropriate for the device.

Fixes #411 , #395 