### PR TITLE
BUGFIX: Get category with localized key

### DIFF
--- a/Classes/UVPostIdeaViewController.m
+++ b/Classes/UVPostIdeaViewController.m
@@ -225,7 +225,7 @@
         [self alertError:NSLocalizedStringFromTableInBundle(@"Please enter your email address before submitting your ticket.", @"UserVoice", [UserVoice bundle], nil)];
     } else {
         [_detailsController showActivityIndicator];
-        _selectedCategoryId = [fields[@"Category"][@"id"] integerValue];
+        _selectedCategoryId = [fields[NSLocalizedStringFromTableInBundle(@"Category", @"UserVoice", [UserVoice bundle], nil)][@"id"] integerValue];
         [self requireUserAuthenticated:email name:name callback:_didAuthenticateCallback];
     }
 }


### PR DESCRIPTION
The category key is localized since it's used in a view, but then read back with an unlocalized string. Also using a localized key to index into the dictionary to properly get the selected category.