### PR TITLE
Style property for _searchController.hidesNavigationBarDuringPresentation

### DIFF
--- a/Classes/UVStyleSheet.m
+++ b/Classes/UVStyleSheet.m
@@ -19,7 +19,9 @@ static UVStyleSheet *instance;
         instance.preferredStatusBarStyle = UIStatusBarStyleDefault;
         instance.navigationBarTintColor = [UINavigationBar appearance].tintColor;
         instance.navigationBarTranslucency = YES;
+        instance.searchBarHideNavigation = true;
     }
+
     return instance;
 }
 

--- a/Classes/UVSuggestionListViewController.m
+++ b/Classes/UVSuggestionListViewController.m
@@ -220,7 +220,7 @@
     _searchController.searchResultsUpdater = self;
     _searchController.searchBar.delegate = self;
     _searchController.searchBar.placeholder = NSLocalizedStringFromTableInBundle(@"Search forum", @"UserVoice", [UserVoice bundle], nil);
-    if (FORMSHEET) {
+    if (FORMSHEET || ![UVStyleSheet instance].searchBarHideNavigation) {
         _searchController.hidesNavigationBarDuringPresentation = false;
     }
     

--- a/Classes/UVWelcomeViewController.m
+++ b/Classes/UVWelcomeViewController.m
@@ -322,9 +322,9 @@
         if ([UVSession currentSession].config.showForum ) {
             _searchController.searchBar.scopeButtonTitles = @[NSLocalizedStringFromTableInBundle(@"All", @"UserVoice", [UserVoice bundle], nil), NSLocalizedStringFromTableInBundle(@"Articles", @"UserVoice", [UserVoice bundle], nil), NSLocalizedStringFromTableInBundle(@"Ideas", @"UserVoice", [UserVoice bundle], nil)];
         }
-        
-        if (FORMSHEET) {
-            _searchController.hidesNavigationBarDuringPresentation = NO;
+
+        if (FORMSHEET || ![UVStyleSheet instance].searchBarHideNavigation) {
+            _searchController.hidesNavigationBarDuringPresentation = false;
         }
         
         _tableView.tableHeaderView = _searchController.searchBar;

--- a/Include/UVStyleSheet.h
+++ b/Include/UVStyleSheet.h
@@ -25,5 +25,6 @@
 @property (nonatomic, assign) BOOL navigationBarTranslucency;
 @property (nonatomic, retain) UIColor *loadingViewBackgroundColor;
 @property (nonatomic, assign) UIStatusBarStyle preferredStatusBarStyle;
+@property (nonatomic, assign) BOOL searchBarHideNavigation;
 
 @end


### PR DESCRIPTION
Allows for setting `_searchController.hidesNavigationBarDuringPresentation` to `false`

Based on the way the navigation controllers are handled, there is a jump when cancelling a search that produces ~64 between the search bar and navigation controller. This change allows for a search controller to be displayed essentially inline.